### PR TITLE
[TECH] Supprimer le repo pix-api-data

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -14,7 +14,6 @@ https://github.com/1024pix/pix-site.git#pix-pro
 https://github.com/1024pix/pix-site.git#pix-site
 https://github.com/1024pix/pix-tutos.git
 https://github.com/1024pix/pix-bot.git
-https://github.com/1024pix/pix-api-data.git
 https://github.com/1024pix/pix-ui.git
 https://github.com/1024pix/scalingo-review-app-manager.git
 https://github.com/1024pix/eslint-plugin.git


### PR DESCRIPTION
## 🌸 Problème
Le repo [pix-api-data](https://github.com/1024pix/pix-api-data) a été archivé le 7 mai 2025. Il n'est donc plus utile de suivre l'état des dépendances.

## 🌳 Proposition
Supprimer le repo pix-api-data.